### PR TITLE
fix: remove deprecated stateless_http parameter from FastMCP initialization

### DIFF
--- a/MCP/KIS Code Assistant MCP/pyproject.toml
+++ b/MCP/KIS Code Assistant MCP/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "fastmcp>=2.11.3",
+    "fastmcp>=3.1.1",
     "pandas>=2.3.1",
     "requests>=2.32.4",
 ]

--- a/MCP/Kis Trading MCP/server.py
+++ b/MCP/Kis Trading MCP/server.py
@@ -47,7 +47,6 @@ def main():
         name="My Awesome MCP Server",
         instructions="This is a server for a specific project.",
         version="1.0.0",
-        stateless_http=False,
     )
 
     # middleware

--- a/backtester/kis_mcp/server.py
+++ b/backtester/kis_mcp/server.py
@@ -61,7 +61,6 @@ mcp = FastMCP(
     host=_host,
     port=_port,
     streamable_http_path="/mcp",
-    stateless_http=True,
 )
 
 # ─── Strategy Tools ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

FastMCP 라이브러리 업데이트에 따라 더 이상 지원되지 않는 stateless_http 파라미터를 제거하여 서버 실행 시 발생하는 TypeError를 해결했습니다.

## Problem
최신 버전(v3.1.1)의 fastmcp 패키지를 사용할 경우, FastMCP 객체 초기화 시 stateless_http 인자를 전달하면 아래와 같은 에러가 발생하며 도커 컨테이너가 정상적으로 실행되지 않는 문제가 있습니다.

```shell
TypeError: FastMCP() no longer accepts `stateless_http`. 
Pass `stateless_http` to `run_http_async()` or `http_app()`, or set FASTMCP_STATELESS_HTTP.
```

관련하여 [PrefectHQ/fastmcp@943af98](https://github.com/PrefectHQ/fastmcp/commit/943af98b0db0a879f384e5f91e9fc50c3dd54e9e) 커밋에서 볼 수 있듯이, stateless_http 인자는 더 이상 FastMCP() 생성자에서 사용할 수 없으며 사용 시 TypeError를 발생시킵니다.
- [PrefectHQ/fastmcp PR#3510](https://github.com/PrefectHQ/fastmcp/pull/3510)

## Key Changes

- 코드 수정: FastMCP 생성자에서 더 이상 지원되지 않는 stateless_http 파라미터를 제거했습니다.
    - 해당 설정이 필요한 경우 이제 환경 변수(FASTMCP_STATELESS_HTTP)를 통해 제어 가능합니다.
- 의존성 업데이트: 최신 구조와의 호환성을 보장하기 위해 fastmcp 최소 버전을 3.1.1로 상향 조정했습니다.
    - `fastmcp>=2.11.3 → fastmcp>=3.1.1`

## Test Results

[x] Docker 빌드 및 MCP 서버 정상 기동 확인
