### PR TITLE
fix: 베트남 매도 모의투자 TR ID 주석 오류 수정 (VTTS0311U → VTTS0310U)

### DIFF
--- a/legacy/Sample01/kis_ovrseastk.py
+++ b/legacy/Sample01/kis_ovrseastk.py
@@ -73,7 +73,7 @@ def get_overseas_order(ord_dv="", excg_cd="", itm_no="", qty=0, unpr=0, tr_cont=
         elif excg_cd == "TKSE":
             tr_id = "TTTS0307U"  # 일본 매도 주문 [모의투자] VTTS0307U
         elif excg_cd in ("HASE", "VNSE"):
-            tr_id = "TTTS0310U"  # 베트남(하노이,호치민) 매도 주문 [모의투자] VTTS0311U
+            tr_id = "TTTS0310U"  # 베트남(하노이,호치민) 매도 주문 [모의투자] VTTS0310U
         else:
             print("해외거래소코드 확인요망!!!")
             return None


### PR DESCRIPTION
## 수정 내용

`legacy/Sample01/kis_ovrseastk.py`의 베트남 매도 주문 모의투자 TR ID 주석 오타 수정.

**변경 전:**
```python
tr_id = "TTTS0310U"  # 베트남(하노이,호치민) 매도 주문 [모의투자] VTTS0311U
```

**변경 후:**
```python
tr_id = "TTTS0310U"  # 베트남(하노이,호치민) 매도 주문 [모의투자] VTTS0310U
```

매수 TR ID(`TTTS0311U` → 모의 `VTTS0311U`)에서 복사 시, 매도 TR ID(`TTTS0310U` → 모의 `VTTS0310U`)의 주석이 반영되지 않은 것으로 보입니다.