### PR TITLE
fix: _smartSleep not updated when switching to paper trading

### DIFF
--- a/backtester/kis_auth.py
+++ b/backtester/kis_auth.py
@@ -146,7 +146,7 @@ def isPaperTrading():  # 모의투자 매매
 def changeTREnv(token_key, svr="prod", product=_cfg["my_prod"]):
     cfg = dict()
 
-    global _isPaper
+    global _isPaper, _smartSleep
     if svr == "prod":  # 실전투자
         ak1 = "my_app"  # 실전투자용 앱키
         ak2 = "my_sec"  # 실전투자용 앱시크리트

--- a/examples_llm/kis_auth.py
+++ b/examples_llm/kis_auth.py
@@ -138,7 +138,7 @@ def isPaperTrading():  # 모의투자 매매
 def changeTREnv(token_key, svr="prod", product=_cfg["my_prod"]):
     cfg = dict()
 
-    global _isPaper
+    global _isPaper, _smartSleep
     if svr == "prod":  # 실전투자
         ak1 = "my_app"  # 실전투자용 앱키
         ak2 = "my_sec"  # 실전투자용 앱시크리트

--- a/examples_user/kis_auth.py
+++ b/examples_user/kis_auth.py
@@ -138,7 +138,7 @@ def isPaperTrading():  # 모의투자 매매
 def changeTREnv(token_key, svr="prod", product=_cfg["my_prod"]):
     cfg = dict()
 
-    global _isPaper
+    global _isPaper, _smartSleep
     if svr == "prod":  # 실전투자
         ak1 = "my_app"  # 실전투자용 앱키
         ak2 = "my_sec"  # 실전투자용 앱시크리트

--- a/strategy_builder/kis_auth.py
+++ b/strategy_builder/kis_auth.py
@@ -146,7 +146,7 @@ def isPaperTrading():  # 모의투자 매매
 def changeTREnv(token_key, svr="prod", product=_cfg["my_prod"]):
     cfg = dict()
 
-    global _isPaper
+    global _isPaper, _smartSleep
     if svr == "prod":  # 실전투자
         ak1 = "my_app"  # 실전투자용 앱키
         ak2 = "my_sec"  # 실전투자용 앱시크리트


### PR DESCRIPTION
## changeTREnv()에서 _smartSleep 전역 선언 누락 수정

기존 코드에서 모의투자(vps)로 전환할 때 API 호출 간격을 느리게 조정하기 위해 _smartSleep = 0.5로 설정되어 있었지만  
**global** _smartSleep 선언이 누락되어 있어 전역 변수에 반영되지 않는 문제가 있었습니다.
이로 인해 의도된 설정과 달리 모의투자 환경에서도 _smartSleep이 초기값인 0.1초로 동작하고 있었습니다.

```
# 변경 전: _smartSleep이 지역 변수로 처리됨
global _isPaper
_smartSleep = 0.5  # 전역 변수에 반영되지 않음

# 변경 후
global _isPaper, _smartSleep
_smartSleep = 0.5  # 전역 변수에 반영 됨
```

### 결과
global _smartSleep 선언을 추가해 모의투자로 전환 시 _smartSleep이 0.5로 정상 반영되도록 수정했습니다.
