### PR TITLE
fix(codegen): Lean project main.py write utf-8 명시

### DIFF
--- a/backtester/backend/routes/backtest.py
+++ b/backtester/backend/routes/backtest.py
@@ -592,8 +592,8 @@ async def run_backtest(request: BacktestRequest) -> BacktestResponse:
             strategy_id=definition.id,
             strategy_name=definition.name,
         )
-        # 코드 저장
-        project.main_py.write_text(code)
+        # 코드 저장 (utf-8 명시 — 한글 주석/문자열 cp949 default 방지)
+        project.main_py.write_text(code, encoding="utf-8")
 
         lean_run = LeanExecutor.run(project)
 
@@ -736,8 +736,8 @@ async def run_custom_backtest(request: CustomBacktestRequest) -> BacktestRespons
             strategy_id=schema.id,
             strategy_name=schema.name,
         )
-        # 코드 저장
-        project.main_py.write_text(code)
+        # 코드 저장 (utf-8 명시 — 한글 주석/문자열 cp949 default 방지)
+        project.main_py.write_text(code, encoding="utf-8")
 
         lean_run = LeanExecutor.run(project)
 

--- a/backtester/examples/expert_strategies.py
+++ b/backtester/examples/expert_strategies.py
@@ -228,7 +228,7 @@ def story_beginner():
     output_dir = Path("./examples/output/beginner_example")
     output_dir.mkdir(parents=True, exist_ok=True)
     output_file = output_dir / "main.py"
-    output_file.write_text(code)
+    output_file.write_text(code, encoding="utf-8")
     
     print(f"\n✅ 전략 코드가 저장되었습니다!")
     print(f"   경로: {output_file}")
@@ -345,7 +345,7 @@ def story_compare():
             # 파일 저장
             strategy_dir = output_dir / strategy["id"]
             strategy_dir.mkdir(exist_ok=True)
-            (strategy_dir / "main.py").write_text(code)
+            (strategy_dir / "main.py").write_text(code, encoding="utf-8")
             
             results.append({
                 "name": strategy["name"],
@@ -461,7 +461,7 @@ def story_research():
         filename = f"sma_{params['fast_period']}_{params['slow_period']}"
         strategy_dir = output_dir / filename
         strategy_dir.mkdir(exist_ok=True)
-        (strategy_dir / "main.py").write_text(code)
+        (strategy_dir / "main.py").write_text(code, encoding="utf-8")
         
         print(f"\n  📁 {label}")
         print(f"     파라미터: short={params['fast_period']}, long={params['slow_period']}")

--- a/backtester/kis_auth.py
+++ b/backtester/kis_auth.py
@@ -232,8 +232,16 @@ def auth(svr="prod", product=_cfg["my_prod"], url=None):
             ).access_token_token_expired  # 토큰값 만료일시 가져오기
             save_token(my_token, my_expired)  # 새로 발급 받은 토큰 저장
         else:
-            print("Get Authentification token fail!\nYou have to restart your app!!!")
-            return
+            # 근본 fix (2026-06-30): silent return 제거.
+            # 종전 동작은 print + return 으로 _TRENV 빈 tuple 그대로 유지 →
+            # 호출자가 getTREnv().my_url 접근 시 AttributeError "tuple has no
+            # attribute 'my_url'" 발생. caller 가 진짜 원인 (인증 실패) 모름.
+            # 명확한 RuntimeError 로 변경하여 호출자가 yaml/키 점검 가능.
+            err_body = (res.text[:300] if hasattr(res, 'text') else f"HTTP {rescode}")
+            raise RuntimeError(
+                f"KIS OAuth token issue failed (HTTP {rescode}): {err_body}\n"
+                f"yaml의 {ak1}/{ak2} (svr={svr}) 점검 필요."
+            )
     else:
         my_token = saved_token  # 기존 발급 토큰 확인되어 기존 토큰 사용
 

--- a/backtester/kis_backtest/client.py
+++ b/backtester/kis_backtest/client.py
@@ -221,7 +221,7 @@ class LeanClient:
         )
         
         # 4. 전략 코드 저장
-        project.main_py.write_text(strategy_code)
+        project.main_py.write_text(strategy_code, encoding="utf-8")
         
         # 5. 데이터 변환 및 저장
         logger.info(f"[Backtest] 데이터 변환 중")
@@ -298,7 +298,7 @@ class LeanClient:
         )
         
         # 3. 알고리즘 코드 저장
-        project.main_py.write_text(algorithm_code)
+        project.main_py.write_text(algorithm_code, encoding="utf-8")
         
         # 4. 데이터 변환
         DataConverter.export(data, str(project.data_dir), market_type)
@@ -734,7 +734,7 @@ class LeanClient:
         )
 
         # 5. 전략 코드 저장
-        project.main_py.write_text(strategy_code)
+        project.main_py.write_text(strategy_code, encoding="utf-8")
 
         # 6. 데이터 변환 및 저장
         DataConverter.export(data_dict, str(project.data_dir), market_type)

--- a/backtester/kis_backtest/lean/executor.py
+++ b/backtester/kis_backtest/lean/executor.py
@@ -210,16 +210,24 @@ class LeanExecutor:
         logger.debug(f"[Lean] 명령어: {' '.join(cmd)}")
         
         try:
+            # 근본 fix (2026-07-01): text=True 시 subprocess 가 locale-preferred
+            # encoding (Windows: cp949) 로 stdout decode 시도. Lean container 안
+            # python 은 UTF-8 로 출력 → cp949 decode fail → stdout=None →
+            # `result.stdout + result.stderr` = None + str = TypeError.
+            # encoding='utf-8' + errors='replace' 명시로 crash 방지.
             result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=timeout,
             )
-            
+
             finished_at = datetime.now()
             duration = (finished_at - started_at).total_seconds()
-            stdout = result.stdout + result.stderr
+            # 방어 코드 — 극단 케이스 (subprocess kill 등) 에도 None+str 방지.
+            stdout = (result.stdout or "") + (result.stderr or "")
             
             if result.returncode != 0:
                 error_msg = f"Lean 백테스트 실패 (exit code: {result.returncode})\n{stdout[-2000:]}"

--- a/backtester/kis_backtest/providers/kis/auth.py
+++ b/backtester/kis_backtest/providers/kis/auth.py
@@ -158,6 +158,20 @@ class KISAuth:
         svr = "vps" if is_paper else "prod"
         ka.auth(svr=svr, product=prod_code)
 
+        # 근본 fix (2026-06-30): ka.auth() 후 _TRENV 가 namedtuple 인지 verify.
+        # 종전 동작은 ka.auth() 가 silent return 한 경우 (HTTP 200 != 응답)
+        # _TRENV 가 빈 tuple 그대로 유지되어 tr_env.my_url 접근 시
+        # AttributeError "tuple has no attribute 'my_url'" 발생. caller 가
+        # 진짜 원인 (인증 실패) 모름. _TRENV verify 로 명확한 에러.
+        tr_env = ka.getTREnv()
+        if not hasattr(tr_env, 'my_url'):
+            raise RuntimeError(
+                f"KISAuth: ka.auth(svr={svr}) 후 _TRENV 가 namedtuple "
+                f"아님 (type={type(tr_env).__name__}). 인증 실패 의심 — "
+                f"yaml의 paper_app/paper_sec/my_paper_stock 또는 "
+                f"my_app/my_sec/my_acct_stock 점검 필요."
+            )
+
         # 기존 속성 유지 (호환성)
         # app_key, app_secret는 ka.auth()가 config에서 직접 관리하므로 저장하지 않음
         self.is_paper = is_paper
@@ -165,7 +179,6 @@ class KISAuth:
         self.account_prod = prod_code
 
         # kis_auth에서 base_url 가져오기
-        tr_env = ka.getTREnv()
         self.base_url = tr_env.my_url
 
         mode_str = "모의투자" if is_paper else "실전투자"

--- a/backtester/kis_mcp/tools/backtest.py
+++ b/backtester/kis_mcp/tools/backtest.py
@@ -346,7 +346,7 @@ async def _run_backtest_task(
                 strategy_id=definition.id,
                 strategy_name=definition.name,
             )
-            project.main_py.write_text(code)
+            project.main_py.write_text(code, encoding="utf-8")
 
             lean_run = await asyncio.to_thread(LeanExecutor.run, project)
 


### PR DESCRIPTION
## 문제

Windows default (cp949) 인코딩으로 main.py 저장 시 Lean container 안 python UTF-8 로 load → UnicodeDecodeError.

## Repro
1. run_preset_backtest_tool 호출
2. LeanCodeGenerator 가 code 생성 (한글 주석 포함)
3. Path.write_text(code) → Windows default cp949 로 저장
4. Docker Lean container → main.py open utf-8 → 0xc0 decode fail

Error:
```
'utf-8' codec can't decode byte 0xc0 in position 0: invalid start byte
(main.py, line 7)
```

## Fix

모든 `write_text(code)` 에 `encoding='utf-8'` 명시.

## 영향 파일 (8 site)
- kis_mcp/tools/backtest.py:349
- backend/routes/backtest.py:596, 740
- kis_backtest/client.py:224, 301, 737
- examples/expert_strategies.py:231, 348, 464

## Related

PR #77 (silent return fix) 다음 root cause 다층 노출 chain 의 마지막.