### PR TITLE
fix: KIS Trading MCP SSE 인증(-32602) 및 FastMCP 호환성 수정

### DIFF
--- a/MCP/Kis Trading MCP/module/mcp_auth.py
+++ b/MCP/Kis Trading MCP/module/mcp_auth.py
@@ -29,7 +29,8 @@ class McpAuthMiddleware(Middleware):
         if get_http_headers is None:
             raise ToolError("Unauthorized: HTTP authentication is not available")
 
-        headers = get_http_headers() or {}
+        # get_http_headers()는 기본적으로 authorization 헤더를 제거하므로 명시적으로 포함시킨다
+        headers = get_http_headers(include={"authorization"}) or {}
         auth_header = headers.get("authorization") or headers.get("Authorization", "")
         api_key = headers.get("x-api-key") or headers.get("X-Api-Key", "")
 

--- a/MCP/Kis Trading MCP/server.py
+++ b/MCP/Kis Trading MCP/server.py
@@ -48,7 +48,6 @@ def main():
         name="My Awesome MCP Server",
         instructions="This is a server for a specific project.",
         version="1.0.0",
-        stateless_http=False,
     )
 
     # middleware


### PR DESCRIPTION
## 개요
KIS Trading MCP 서버가 MCP 클라이언트(예: Claude Code)에서 연결 실패(`-32602`)하고, 컨테이너/서버 실행 시 오류가 나던 두 문제를 조치합니다.

## 문제 및 원인
### 1. SSE 인증 실패 (`-32602 Invalid request parameters`)
- `McpAuthMiddleware`가 `get_http_headers()`(기본값)로 헤더를 읽는데, FastMCP는 이 함수에서 **`authorization` 헤더를 기본적으로 제거**합니다.
- 따라서 클라이언트가 올바른 `Authorization: Bearer <token>`을 전송해도 미들웨어에는 빈 값으로 도달 → 토큰 검증 실패 → 모든 요청이 인증 거부됩니다.
- SSE·streamable-http 양쪽에서 재현되며, 동일 토큰을 `x-api-key` 헤더로 보내면 정상 통과하는 것으로 원인을 확정했습니다.

### 2. 실행 시 FastMCP 호환성 오류
- `FastMCP(...)` 생성자에 전달하던 `stateless_http=False` 인자가 최신 FastMCP(3.4.3)에서 미지원이라 서버 기동 시 오류가 발생합니다.

## 변경 사항
- `MCP/Kis Trading MCP/module/mcp_auth.py`: `get_http_headers(include={"authorization"})`로 authorization 헤더를 명시적으로 포함.
- `MCP/Kis Trading MCP/server.py`: 미지원 인자 `stateless_http=False` 제거.

## 검증
- 재빌드 후 실행 중인 SSE 서버에 `Authorization: Bearer <token>`로 `initialize`를 직접 요청 → `serverInfo` 포함 정상 응답 확인.
- Claude Code `/mcp` 재연결 성공 및 8개 툴(auth, domestic_stock, domestic_futureoption, domestic_bond, overseas_stock, overseas_futureoption, elw, etfetn) 정상 로드 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)