### PR TITLE
docs(overseas-stock): clarify inquire-nccs sample pagination and completeness

### DIFF
--- a/examples_llm/overseas_stock/inquire_nccs/inquire_nccs.py
+++ b/examples_llm/overseas_stock/inquire_nccs/inquire_nccs.py
@@ -46,18 +46,36 @@ def inquire_nccs(
     Args:
         cano (str): 계좌번호 체계(8-2)의 앞 8자리
         acnt_prdt_cd (str): 계좌번호 체계(8-2)의 뒤 2자리
-        ovrs_excg_cd (str): NASD : 나스닥 NYSE : 뉴욕  AMEX : 아멕스 SEHK : 홍콩 SHAA : 중국상해 SZAA : 중국심천 TKSE : 일본 HASE : 베트남 하노이 VNSE : 베트남 호치민  * NASD 인 경우만 미국전체로 조회되며 나머지 거래소 코드는 해당 거래소만 조회됨 * 공백 입력 시 다음조회가 불가능하므로, 반드시 거래소코드 입력해야 함
+        ovrs_excg_cd (str): 해외거래소코드(필수).
+            기존 설명은 NASD를 "나스닥"과 "미국전체"로 동시에 표기합니다.
+            따라서 이 문서에서는 확인 전까지 NASD의 조회 범위를 확정하지 않습니다.
+            NYSE : 뉴욕, AMEX : 아멕스, SEHK : 홍콩, SHAA : 중국상해,
+            SZAA : 중국심천, TKSE : 일본, HASE : 베트남 하노이,
+            VNSE : 베트남 호치민
         sort_sqn (str): DS : 정순 그외 : 역순  [header tr_id: TTTS3018R] ""(공란)
         FK200 (str): 공란 : 최초 조회시 이전 조회 Output CTX_AREA_FK200값 : 다음페이지 조회시(2번째부터)
         NK200 (str): 공란 : 최초 조회시 이전 조회 Output CTX_AREA_NK200값 : 다음페이지 조회시(2번째부터)
-        env_dv (str): 실전모의구분 (real:실전, demo:모의)
+        env_dv (str): 실전모의구분 (real:실전, demo:모의).
+            현재 구현은 이 값으로 TR ID를 분기하지 않고 TTTS3018R을 사용합니다.
         tr_cont (str): 연속 거래 여부
         dataframe (Optional[pd.DataFrame]): 누적 데이터프레임
         depth (int): 현재 재귀 깊이
         max_depth (int): 최대 재귀 깊이 (기본값: 10)
         
     Returns:
-        Optional[pd.DataFrame]: 해외주식 미체결내역 데이터
+        Optional[pd.DataFrame]: 해외주식 미체결내역 데이터.
+            반환값에는 전체 조회 완료, 부분 조회, 실패를 구분하는 상태가 없습니다.
+
+    Notes:
+        현재 샘플 구현은 응답 헤더 tr_cont가 M 또는 F이면 응답의
+        ctx_area_fk200과 ctx_area_nk200을 다음 요청에 전달하고
+        tr_cont="N"으로 다시 호출합니다. 이는 현재 코드의 동작 설명이며,
+        API 연속조회 계약을 확정하는 문구가 아닙니다.
+
+        max_depth 도달 또는 후속 API 호출 실패 시 이미 수집한 DataFrame을
+        반환합니다. 따라서 빈 DataFrame은 정상 0건과 첫 호출 실패를
+        구분하지 않으며, 비어 있지 않은 DataFrame도 전체 페이지 완료를
+        보장하지 않습니다.
         
     Example:
         >>> df = inquire_nccs(

--- a/examples_user/overseas_stock/overseas_stock_functions.py
+++ b/examples_user/overseas_stock/overseas_stock_functions.py
@@ -927,18 +927,36 @@ def inquire_nccs(
     Args:
         cano (str): 계좌번호 체계(8-2)의 앞 8자리
         acnt_prdt_cd (str): 계좌번호 체계(8-2)의 뒤 2자리
-        ovrs_excg_cd (str): NASD : 나스닥 NYSE : 뉴욕  AMEX : 아멕스 SEHK : 홍콩 SHAA : 중국상해 SZAA : 중국심천 TKSE : 일본 HASE : 베트남 하노이 VNSE : 베트남 호치민  * NASD 인 경우만 미국전체로 조회되며 나머지 거래소 코드는 해당 거래소만 조회됨 * 공백 입력 시 다음조회가 불가능하므로, 반드시 거래소코드 입력해야 함
+        ovrs_excg_cd (str): 해외거래소코드(필수).
+            기존 설명은 NASD를 "나스닥"과 "미국전체"로 동시에 표기합니다.
+            따라서 이 문서에서는 확인 전까지 NASD의 조회 범위를 확정하지 않습니다.
+            NYSE : 뉴욕, AMEX : 아멕스, SEHK : 홍콩, SHAA : 중국상해,
+            SZAA : 중국심천, TKSE : 일본, HASE : 베트남 하노이,
+            VNSE : 베트남 호치민
         sort_sqn (str): DS : 정순 그외 : 역순  [header tr_id: TTTS3018R] ""(공란)
         FK200 (str): 공란 : 최초 조회시 이전 조회 Output CTX_AREA_FK200값 : 다음페이지 조회시(2번째부터)
         NK200 (str): 공란 : 최초 조회시 이전 조회 Output CTX_AREA_NK200값 : 다음페이지 조회시(2번째부터)
-        env_dv (str): 실전모의구분 (real:실전, demo:모의)
+        env_dv (str): 실전모의구분 (real:실전, demo:모의).
+            현재 구현은 이 값으로 TR ID를 분기하지 않고 TTTS3018R을 사용합니다.
         tr_cont (str): 연속 거래 여부
         dataframe (Optional[pd.DataFrame]): 누적 데이터프레임
         depth (int): 현재 재귀 깊이
         max_depth (int): 최대 재귀 깊이 (기본값: 10)
         
     Returns:
-        Optional[pd.DataFrame]: 해외주식 미체결내역 데이터
+        Optional[pd.DataFrame]: 해외주식 미체결내역 데이터.
+            반환값에는 전체 조회 완료, 부분 조회, 실패를 구분하는 상태가 없습니다.
+
+    Notes:
+        현재 샘플 구현은 응답 헤더 tr_cont가 M 또는 F이면 응답의
+        ctx_area_fk200과 ctx_area_nk200을 다음 요청에 전달하고
+        tr_cont="N"으로 다시 호출합니다. 이는 현재 코드의 동작 설명이며,
+        API 연속조회 계약을 확정하는 문구가 아닙니다.
+
+        max_depth 도달 또는 후속 API 호출 실패 시 이미 수집한 DataFrame을
+        반환합니다. 따라서 빈 DataFrame은 정상 0건과 첫 호출 실패를
+        구분하지 않으며, 비어 있지 않은 DataFrame도 전체 페이지 완료를
+        보장하지 않습니다.
         
     Example:
         >>> df = inquire_nccs(


### PR DESCRIPTION
## 요약

`inquire_nccs`의 실행 동작은 변경하지 않고, 두 공식 sample 사본의
docstring을 현재 코드와 일치시키는 문서 변경입니다.

- `NASD`를 "나스닥"과 "미국전체"로 동시에 설명하던 문구를 제거했습니다.
- 현재 sample의 연속조회 구현을 API 계약이 아닌 **코드 동작**으로 명시했습니다.
- `env_dv`가 현재 TR ID 선택에 사용되지 않는 사실을 기록했습니다.
- 부분 결과, 정상 0건, 첫 호출 실패를 반환값만으로 구분할 수 없음을 기록했습니다.

확인되지 않은 거래소 범위, 주문·체결 유일키, 수량 의미를 새로운 계약으로
단정하지 않습니다.

## 확인된 불일치

기준 commit: `885dd4e2f5c37e4f7e23dd63c15555a9967bc7bc`

- [잔고 sample](https://github.com/koreainvestment/open-trading-api/blob/885dd4e2f5c37e4f7e23dd63c15555a9967bc7bc/examples_llm/overseas_stock/inquire_balance/inquire_balance.py#L49)은 실전 `NASD=미국전체`, `NAS=나스닥`으로 설명합니다.
- [미체결 sample](https://github.com/koreainvestment/open-trading-api/blob/885dd4e2f5c37e4f7e23dd63c15555a9967bc7bc/examples_llm/overseas_stock/inquire_nccs/inquire_nccs.py#L49)은 같은 문장에서 `NASD=나스닥`과 `NASD=미국전체`를 함께 적고 있습니다.
- [미체결 구현](https://github.com/koreainvestment/open-trading-api/blob/885dd4e2f5c37e4f7e23dd63c15555a9967bc7bc/examples_llm/overseas_stock/inquire_nccs/inquire_nccs.py#L88-L148)은 `M/F`에서 두 CTX와 `tr_cont="N"`을 사용해 재귀 호출하고, 깊이 제한 또는 후속 실패 때 누적 데이터를 반환합니다.
- [체결 sample](https://github.com/koreainvestment/open-trading-api/blob/885dd4e2f5c37e4f7e23dd63c15555a9967bc7bc/examples_llm/overseas_stock/inquire_ccnl/inquire_ccnl.py#L57-L82)은 `NASD=미국시장 전체`라고 설명하며, 실전 전종목 `PDNO` 설명은 `%`이지만 예시는 빈 문자열을 사용합니다.

API 포털에는 미체결 조회의 연속조회 token 설명과
`tr_cont를 이용한 다음조회 불가`라는 설명이 함께 있어, 이 PR은 어느 쪽도
임의로 공식 계약으로 선택하지 않습니다.

## 공식 확인 요청

다음 항목을 TR·실전/모의 환경별로 확인 부탁드립니다.

1. `TTTS3018R`의 연속조회 지원 여부, 최초·후속·종료 `tr_cont`, 두 CTX의
   필수 여부와 token 누락·반복 의미
2. 잔고·미체결·체결에서 `NASD`, `NAS`, `NYSE`, `AMEX`, `%`, 공백의 조회
   범위와 호출 간 중복 여부
3. `TTTS3035R`/`VTTS3035R`의 계좌 전체 조회를 위한 정확한 `PDNO` 및
   `OVRS_EXCG_CD` 값
4. `TTTS3012R`/`VTTS3012R`의 `output1`·`output2` 역할, 페이지별 행 구조,
   잔고 row identity와 중복 범위
5. 미체결·체결 row의 공식 identity와 유일성 범위, 개별 체결 식별 가능 여부,
   `ft_ccld_qty`·`nccs_qty`의 누적/잔여 의미
6. 미체결 모의투자 지원 여부. 현재 sample은 `env_dv`를 받지만 TR ID는
   `TTTS3018R`로 고정되어 있습니다.

## 명시적으로 단정하지 않는 내용

- `F/M`에서 CTX 하나만 있어도 후속조회가 유효하다는 규칙
- blank 또는 반복 CTX를 정상 완료로 간주하는 규칙
- `(ord_dt, ord_gno_brno, odno, exchange)`의 공식 유일성
- `ft_ccld_qty`가 항상 누적 체결수량이라는 의미

## Draft 해제 조건

- [ ] 유지관리자가 위 계약을 TR·환경별로 확인합니다.
- [ ] 두 `inquire_nccs` 사본에 동일한 확정 계약과 부분 결과 의미가 반영됩니다.
- [ ] API 포털의 상충 문구가 함께 수정되거나, KIS가 관리하는 후속 수정 항목의
      공식 링크가 제공됩니다.

## 범위 및 검증

- docstring만 변경하며 인증, API 호출, 주문 동작, 함수 반환 동작은 변경하지
  않습니다.
- 실제 계좌·token·raw 응답을 사용하지 않았습니다.
- 두 Python 파일을 AST parsing했고 두 `inquire_nccs` docstring이 동일함을
  확인했습니다.
- `git diff --check`를 통과했습니다.
