### PR TITLE
fix: OS 간 경로 호환성을 위해 os.path.join 적용

### DIFF
--- a/stocks_info/kis_kosdaq_code_mst.py
+++ b/stocks_info/kis_kosdaq_code_mst.py
@@ -13,27 +13,29 @@ def kosdaq_master_download(base_dir, verbose=False):
     cwd = os.getcwd()
     if (verbose): print(f"current directory is {cwd}")
     ssl._create_default_https_context = ssl._create_unverified_context
-    
-    urllib.request.urlretrieve("https://new.real.download.dws.co.kr/common/master/kosdaq_code.mst.zip",
-                               base_dir + "\\kosdaq_code.zip")
+
+    urllib.request.urlretrieve(
+        "https://new.real.download.dws.co.kr/common/master/kosdaq_code.mst.zip",
+        os.path.join(base_dir, "kosdaq_code.zip"),
+    )
 
     os.chdir(base_dir)
     if (verbose): print(f"change directory to {base_dir}")
     kosdaq_zip = zipfile.ZipFile('kosdaq_code.zip')
     kosdaq_zip.extractall()
-    
+
     kosdaq_zip.close()
 
     if os.path.exists("kosdaq_code.zip"):
         os.remove("kosdaq_code.zip")
 
 def get_kosdaq_master_dataframe(base_dir):
-    file_name = base_dir + "\\kosdaq_code.mst"
-    tmp_fil1 = base_dir + "\\kosdaq_code_part1.tmp"
-    tmp_fil2 = base_dir + "\\kosdaq_code_part2.tmp"
+    file_name = os.path.join(base_dir, "kosdaq_code.mst")
+    tmp_fil1 = os.path.join(base_dir, "kosdaq_code_part1.tmp")
+    tmp_fil2 = os.path.join(base_dir, "kosdaq_code_part2.tmp")
 
-    wf1 = open(tmp_fil1, mode="w")
-    wf2 = open(tmp_fil2, mode="w")
+    wf1 = open(tmp_fil1, mode="w", encoding="cp949")
+    wf2 = open(tmp_fil2, mode="w", encoding="cp949")
 
     with open(file_name, mode="r", encoding="cp949") as f:
         for row in f:

--- a/stocks_info/kis_kospi_code_mst.py
+++ b/stocks_info/kis_kospi_code_mst.py
@@ -13,8 +13,10 @@ def kospi_master_download(base_dir, verbose=False):
     if (verbose): print(f"current directory is {cwd}")
     ssl._create_default_https_context = ssl._create_unverified_context
 
-    urllib.request.urlretrieve("https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip",
-                               base_dir + "\\kospi_code.zip")
+    urllib.request.urlretrieve(
+        "https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip",
+        os.path.join(base_dir, "kospi_code.zip")
+    )
 
     os.chdir(base_dir)
     if (verbose): print(f"change directory to {base_dir}")
@@ -28,12 +30,12 @@ def kospi_master_download(base_dir, verbose=False):
 
 
 def get_kospi_master_dataframe(base_dir):
-    file_name = base_dir + "\\kospi_code.mst"
-    tmp_fil1 = base_dir + "\\kospi_code_part1.tmp"
-    tmp_fil2 = base_dir + "\\kospi_code_part2.tmp"
+    file_name = os.path.join(base_dir, "kospi_code.mst")
+    tmp_fil1 = os.path.join(base_dir, "kospi_code_part1.tmp")
+    tmp_fil2 = os.path.join(base_dir, "kospi_code_part2.tmp")
 
-    wf1 = open(tmp_fil1, mode="w")
-    wf2 = open(tmp_fil2, mode="w")
+    wf1 = open(tmp_fil1, mode="w", encoding="cp949")
+    wf2 = open(tmp_fil2, mode="w", encoding="cp949")
 
     with open(file_name, mode="r", encoding="cp949") as f:
         for row in f:
@@ -92,14 +94,14 @@ def get_kospi_master_dataframe(base_dir):
     del (df2)
     os.remove(tmp_fil1)
     os.remove(tmp_fil2)
-    
+
     print("Done")
 
     return df
 
 
 kospi_master_download(base_dir)
-df = get_kospi_master_dataframe(base_dir) 
+df = get_kospi_master_dataframe(base_dir)
 
 #df3 = df[df['KRX증권'] == 'Y']
 df3 = df


### PR DESCRIPTION
## 1. 작업 배경
윈도우 외의 환경(Linux, macOS)에서 스크립트 실행 시, 하드코딩된 경로 구분자와 OS별 기본 인코딩 차이로 인해 정상적으로 데이터가 파싱되지 않는 문제를 발견

## 2. 주요 변경 사항
- 하드코딩된 윈도우식 경로 구분자(`\\`)를 `os.path.join()`으로 교체
- `tmp_fil1`, `tmp_fil2` 등 임시 파일을 생성(`mode="w"`)할 때 인코딩이 생략되어 있어 리눅스 환경에서는 `UTF-8`로 처리되는 문제가 있어 `encoding="cp949"`를 명시적으로 추가

## 3. 수정한 파일
1. `stocks_info/kis_kosdaq_code_mst.py`
2. `stocks_info/kis_kospi_code_mst.py`